### PR TITLE
Affiner le portfolio selon le parcours du lycée

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -200,6 +200,22 @@ img {
   font-size: 1.1rem;
 }
 
+.hero-note {
+  margin-top: 0.75rem;
+  color: var(--text-muted);
+  font-size: 0.95rem;
+}
+
+.hero-note a {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+.hero-note a:hover,
+.hero-note a:focus {
+  text-decoration: underline;
+}
+
 .cta-group {
   display: flex;
   flex-wrap: wrap;

--- a/cv/index.html
+++ b/cv/index.html
@@ -1,0 +1,257 @@
+<!DOCTYPE html>
+<html lang="fr">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>CV - Léo OMNES</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        color-scheme: light;
+        --bg: #f5f7fb;
+        --card: #ffffff;
+        --text: #1d1f2f;
+        --muted: #5a5f7a;
+        --accent: #3b82f6;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        font-family: 'Poppins', system-ui, -apple-system, BlinkMacSystemFont,
+          'Segoe UI', sans-serif;
+        background: var(--bg);
+        color: var(--text);
+      }
+
+      header {
+        background: linear-gradient(135deg, #1d4ed8, #3b82f6);
+        color: #fff;
+        padding: 3rem 1.5rem 2.5rem;
+      }
+
+      header .container {
+        max-width: 900px;
+        margin: 0 auto;
+        display: flex;
+        flex-direction: column;
+        gap: 1rem;
+      }
+
+      header h1 {
+        margin: 0;
+        font-size: clamp(2rem, 4vw, 2.75rem);
+        font-weight: 600;
+      }
+
+      header p {
+        margin: 0;
+        font-weight: 400;
+        max-width: 640px;
+      }
+
+      .contact-grid {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 1.5rem;
+        font-size: 0.95rem;
+      }
+
+      .contact-grid a {
+        color: #fff;
+        text-decoration: none;
+      }
+
+      main {
+        max-width: 900px;
+        margin: -2rem auto 3rem;
+        padding: 0 1.5rem;
+      }
+
+      .card {
+        background: var(--card);
+        border-radius: 16px;
+        box-shadow: 0 24px 48px rgba(8, 15, 52, 0.08);
+        padding: 2.25rem;
+        margin-bottom: 1.75rem;
+      }
+
+      .section-title {
+        margin: 0 0 1.25rem;
+        font-size: 1.35rem;
+        font-weight: 600;
+      }
+
+      .item {
+        margin-bottom: 1.5rem;
+      }
+
+      .item:last-child {
+        margin-bottom: 0;
+      }
+
+      .item h3 {
+        margin: 0;
+        font-size: 1.1rem;
+        font-weight: 600;
+      }
+
+      .item .meta {
+        margin: 0.35rem 0;
+        font-size: 0.9rem;
+        color: var(--muted);
+      }
+
+      .item p {
+        margin: 0;
+        line-height: 1.6;
+      }
+
+      ul.skill-list {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+        gap: 0.75rem 1.5rem;
+      }
+
+      ul.skill-list li {
+        margin: 0;
+        padding-left: 1rem;
+        position: relative;
+      }
+
+      ul.skill-list li::before {
+        content: '•';
+        position: absolute;
+        left: 0;
+        color: var(--accent);
+      }
+
+      .actions {
+        display: flex;
+        justify-content: flex-end;
+        gap: 1rem;
+        flex-wrap: wrap;
+        margin-top: 2rem;
+      }
+
+      .actions a {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.5rem;
+        background: var(--accent);
+        color: #fff;
+        padding: 0.75rem 1.25rem;
+        border-radius: 999px;
+        text-decoration: none;
+        font-weight: 500;
+      }
+
+      @media (max-width: 600px) {
+        header {
+          padding: 2.5rem 1.25rem 2rem;
+        }
+
+        main {
+          padding: 0 1.25rem;
+        }
+
+        .card {
+          padding: 1.75rem;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <div class="container">
+        <h1>Léo OMNES</h1>
+        <p>Étudiant en BTS SIO SLAM &amp; développeur en alternance dans mon lycée Robert Schuman</p>
+        <div class="contact-grid">
+          <span>Paris 20e, France</span>
+          <a href="mailto:leomnes25@gmail.com">leomnes25@gmail.com</a>
+          <a href="https://github.com/ollo25" target="_blank" rel="noopener noreferrer">github.com/ollo25</a>
+        </div>
+      </div>
+    </header>
+    <main>
+      <section class="card">
+        <h2 class="section-title">Profil</h2>
+        <p>
+          Alternant en BTS SIO option SLAM directement dans mon lycée Robert
+          Schuman, j'appuie le service numérique dans la modernisation des
+          outils des équipes pédagogiques. Mon stage de plus d'un mois au sein du
+          même service a renforcé mon expertise en automatisation de reportings
+          et en accompagnement des utilisateurs.
+        </p>
+      </section>
+      <section class="card">
+        <h2 class="section-title">Expériences professionnelles</h2>
+        <div class="item">
+          <h3>Développeur en alternance</h3>
+          <p class="meta">Lycée Robert Schuman — Services numériques | 2024 — Aujourd'hui</p>
+          <p>
+            Développement et maintenance d'outils internes pour le suivi
+            pédagogique, automatisation des indicateurs clés et support aux
+            utilisateurs sur les applications métiers du lycée.
+          </p>
+        </div>
+        <div class="item">
+          <h3>Stagiaire développeur applicatif</h3>
+          <p class="meta">Lycée Robert Schuman — Services numériques | 2023 (stage de plus d'un mois)</p>
+          <p>
+            Stage prolongé dédié à la maintenance du portail interne, à
+            l'automatisation des reportings et à la formation des équipes
+            administratives aux nouveaux outils.
+          </p>
+        </div>
+      </section>
+      <section class="card">
+        <h2 class="section-title">Formation</h2>
+        <div class="item">
+          <h3>BTS SIO option SLAM</h3>
+          <p class="meta">Lycée Robert Schuman — Dugny | 2024 — 2026</p>
+          <p>
+            Parcours axé sur le développement applicatif, la gestion de bases de
+            données, la cybersécurité et la conduite de projet en alternance.
+          </p>
+        </div>
+        <div class="item">
+          <h3>Baccalauréat général</h3>
+          <p class="meta">Lycée Sainte Louise — Paris 20e | 2021 — 2024</p>
+          <p>
+            Spécialités Mathématiques et Physique-Chimie ; option SVT suivie
+            puis abandonnée en terminale au lycée Sainte Louise (Paris 20e).
+          </p>
+        </div>
+      </section>
+      <section class="card">
+        <h2 class="section-title">Compétences clés</h2>
+        <ul class="skill-list">
+          <li>PHP / Symfony</li>
+          <li>HTML, CSS &amp; JavaScript</li>
+          <li>Python</li>
+          <li>Talend Data Integration</li>
+          <li>SQL &amp; MySQL</li>
+          <li>Java &amp; C#</li>
+          <li>Automatisation de reportings</li>
+          <li>Documentation technique</li>
+        </ul>
+      </section>
+      <div class="actions">
+        <a href="../index.html">Retour au portfolio</a>
+      </div>
+    </main>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta
       name="description"
-      content="Portfolio de Léo OMNES, étudiant en BTS SIO SLAM et assistant de suivi projets informatiques."
+      content="Portfolio de Léo OMNES, étudiant en BTS SIO SLAM en alternance dans son lycée Robert Schuman, stage de plus d'un mois au même service et baccalauréat général (Maths, Physique-Chimie, option SVT abandonnée) au lycée Sainte Louise."
     />
     <title>Portfolio - Léo OMNES | Développeur BTS SIO SLAM</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
@@ -38,17 +38,24 @@
           <li><a href="#parcours">Parcours</a></li>
           <li><a href="#projets">Projets</a></li>
           <li><a href="#contact">Contact</a></li>
+          <li>
+            <a href="cv/index.html" target="_blank" rel="noopener noreferrer"
+              >CV</a
+            >
+          </li>
         </ul>
       </nav>
       <div class="hero-content container">
         <p class="eyebrow" data-field="tagline">
-          Étudiant BTS SIO SLAM &amp; assistant projets informatiques
+          Étudiant BTS SIO SLAM &amp; développeur en alternance dans mon lycée
+          Robert Schuman
         </p>
         <h1 class="hero-title" data-field="fullName">Léo OMNES</h1>
         <p class="hero-subtitle" data-field="heroDescription">
-          Étudiant en alternance chez SFR Business, je conçois des solutions
-          logicielles fiables en automatisant les reportings et en pilotant les
-          indicateurs de production.
+          Étudiant en alternance et ancien stagiaire au lycée Robert Schuman,
+          je conçois des outils numériques pour accompagner les équipes
+          pédagogiques, automatiser les reportings et faciliter le suivi des
+          projets de l'établissement.
         </p>
         <div class="cta-group">
           <a class="btn btn-primary" data-link="primaryCta" href="#projets"
@@ -58,6 +65,9 @@
             >Me contacter</a
           >
         </div>
+        <p class="hero-note">
+          <a href="cv/index.html" rel="noopener noreferrer">Consulter mon CV en ligne</a>
+        </p>
       </div>
     </header>
 
@@ -68,19 +78,21 @@
           <div class="about-grid">
             <div class="about-description" data-section="about.paragraphs">
               <p>
-                Alternant en BTS SIO option SLAM au lycée Robert Schuman, je
-                contribue chez SFR Business au suivi et à l'optimisation de
-                projets informatiques orientés data et reporting.
+                Alternant en BTS SIO option SLAM directement au lycée Robert
+                Schuman, j'appuie le service numérique dans la modernisation
+                des outils utilisés par les équipes pédagogiques.
               </p>
               <p>
-                Je développe des tableaux de bord, j'automatise la diffusion
-                d'indicateurs et je documente les processus pour garantir la
-                fiabilité des applications livrées.
+                Je développe et maintiens des applications internes, mets en
+                place des automatisations pour fiabiliser les reportings et
+                documente chaque procédure afin d'assurer la continuité des
+                projets.
               </p>
               <p>
-                Passionné de programmation, d'escalade et de jeux vidéo, je
-                reste à l'affût des nouveautés pour proposer des solutions
-                utiles et engageantes.
+                Après un stage de plus d'un mois au sein du même service, j'ai
+                poursuivi l'aventure en alternance pour faire évoluer les
+                solutions internes tout en progressant sur mes compétences
+                techniques.
               </p>
             </div>
             <ul class="about-highlights" data-section="about.highlights">
@@ -90,8 +102,8 @@
               </li>
               <li>
                 <span class="label">Email</span>
-                <a class="value" href="mailto:leoomnes25@gmail.com"
-                  >leoomnes25@gmail.com</a
+                <a class="value" href="mailto:leomnes25@gmail.com"
+                  >leomnes25@gmail.com</a
                 >
               </li>
               <li>
@@ -104,8 +116,8 @@
               </li>
               <li>
                 <span class="label">GitHub</span>
-                <a class="value" href="https://github.com/oiie25"
-                  >github.com/oiie25</a
+                <a class="value" href="https://github.com/ollo25"
+                  >github.com/ollo25</a
                 >
               </li>
             </ul>
@@ -180,14 +192,16 @@
                 <header>
                   <p class="timeline-period">2024 — Aujourd’hui</p>
                   <h3 class="timeline-title">
-                    Assistant de suivi projets informatiques
+                    Développeur en alternance (BTS SIO)
                   </h3>
-                  <p class="timeline-organization">SFR Business</p>
+                  <p class="timeline-organization">
+                    Lycée Robert Schuman — Services numériques
+                  </p>
                 </header>
                 <p>
-                  Supervision quotidienne des indicateurs, automatisation des
-                  rapports, support administratif et coordination avec l'équipe
-                  data pour les tableaux de bord.
+                  Développement et maintenance d'outils internes pour le suivi
+                  pédagogique, automatisation des indicateurs et accompagnement
+                  des utilisateurs de l'établissement.
                 </p>
               </div>
             </article>
@@ -195,14 +209,16 @@
               <div class="timeline-marker" aria-hidden="true"></div>
               <div class="timeline-content">
                 <header>
-                  <p class="timeline-period">2023</p>
-                  <h3 class="timeline-title">Développeur web (stage)</h3>
-                  <p class="timeline-organization">GIC Informatique</p>
+                  <p class="timeline-period">2023 (stage de plus d'un mois)</p>
+                  <h3 class="timeline-title">Stagiaire développeur applicatif</h3>
+                  <p class="timeline-organization">
+                    Lycée Robert Schuman — Services numériques
+                  </p>
                 </header>
                 <p>
-                  Maintenance d'applications métiers, corrections de bugs,
-                  conception d'interfaces, déploiement d'un accès distant et
-                  support technique de niveau 1.
+                  Stage prolongé au sein du service numérique du lycée avec
+                  maintenance du portail interne, automatisation des reportings
+                  et formation des équipes administratives.
                 </p>
               </div>
             </article>
@@ -226,13 +242,16 @@
               <div class="timeline-marker" aria-hidden="true"></div>
               <div class="timeline-content">
                 <header>
-                  <p class="timeline-period">2022 — 2024</p>
-                  <h3 class="timeline-title">Baccalauréat STI2D</h3>
-                  <p class="timeline-organization">Lycée Montaleau</p>
+                  <p class="timeline-period">2021 — 2024</p>
+                  <h3 class="timeline-title">Baccalauréat général</h3>
+                  <p class="timeline-organization">
+                    Lycée Sainte Louise — Paris 20e
+                  </p>
                 </header>
                 <p>
-                  Spécialités Mathématiques, Numérique et Sciences de l'Ingénieur
-                  – mention bien.
+                  Spécialités Mathématiques et Physique-Chimie ; option SVT
+                  suivie puis abandonnée en terminale au lycée Sainte Louise
+                  (Paris 20e).
                 </p>
               </div>
             </article>
@@ -246,49 +265,50 @@
             <div>
               <h2 class="section-title" data-field="projects.title">Projets</h2>
               <p class="section-intro" data-field="projects.intro">
-                Sélection de projets académiques et personnels illustrant mon
-                approche terrain.
+                Projets menés au lycée Robert Schuman et dans le cadre de mon
+                BTS SIO SLAM.
               </p>
             </div>
             <div class="filters" data-section="projects.filters"></div>
           </div>
           <div class="project-grid" data-section="projects.items">
             <article class="project-card">
-              <h3>Application de concours national</h3>
+              <h3>Portail de suivi pédagogique</h3>
               <p>
-                Plateforme collaborative pour gérer les inscriptions, votes et
-                tableaux de bord d'un concours national en temps réel.
+                Application interne du lycée pour centraliser les indicateurs,
+                suivre les ateliers et partager les actions des équipes
+                pédagogiques.
               </p>
-              <p class="project-tech">Symfony · Bootstrap · JavaScript</p>
+              <p class="project-tech">Symfony · MySQL · Bootstrap</p>
               <div class="project-links">
-                <a href="https://github.com/oiie25" target="_blank" rel="noopener noreferrer"
-                  >Aperçu GitHub</a
+                <a href="https://github.com/ollo25" target="_blank" rel="noopener noreferrer"
+                  >Structure du dépôt</a
                 >
               </div>
             </article>
             <article class="project-card">
-              <h3>Gestion de base de données MySQL</h3>
+              <h3>Automatisation des reportings</h3>
               <p>
-                Modélisation, scripts SQL (requêtes, triggers) et reporting pour
-                piloter les données d'un cas métier.
+                Scripts Python et flux Talend pour générer les bilans mensuels
+                et diffuser automatiquement les reportings aux équipes du lycée.
               </p>
-              <p class="project-tech">MySQL · SQL · Talend</p>
+              <p class="project-tech">Python · Talend Data Integration · SQL</p>
               <div class="project-links">
-                <a href="https://github.com/oiie25" target="_blank" rel="noopener noreferrer"
-                  >Documentation</a
+                <a href="https://github.com/ollo25" target="_blank" rel="noopener noreferrer"
+                  >Exemples de scripts</a
                 >
               </div>
             </article>
             <article class="project-card">
               <h3>Portfolio personnel</h3>
               <p>
-                Site vitrine responsive en HTML, CSS et JavaScript avec
-                animations et section contact interactive.
+                Site vitrine responsive présentant mon parcours BTS SIO, mes
+                expériences au lycée et mes compétences techniques.
               </p>
               <p class="project-tech">HTML · CSS · JavaScript</p>
               <div class="project-links">
                 <a
-                  href="https://github.com/oiie25/portfolio"
+                  href="https://github.com/ollo25/portfolio"
                   target="_blank"
                   rel="noopener noreferrer"
                   >Code source</a
@@ -303,9 +323,9 @@
         <div class="container">
           <h2 class="section-title" data-field="contact.title">Contact</h2>
           <p class="section-intro" data-field="contact.subtitle">
-            En alternance chez SFR Business, je reste disponible pour échanger
-            sur vos projets, un besoin de reporting ou une opportunité de
-            collaboration.
+            En alternance et après mon stage au lycée Robert Schuman, je reste
+            disponible pour échanger sur vos projets numériques, vos besoins en
+            reporting ou une collaboration.
           </p>
           <div class="contact-grid">
             <div class="contact-card">
@@ -315,8 +335,8 @@
                   <span class="label">Email</span>
                   <a
                     data-link="contact.email"
-                    href="mailto:leoomnes25@gmail.com"
-                    >leoomnes25@gmail.com</a
+                    href="mailto:leomnes25@gmail.com"
+                    >leomnes25@gmail.com</a
                   >
                 </li>
                 <li>
@@ -328,7 +348,7 @@
                 <li class="socials" data-section="contact.socials">
                   <span class="label">Réseaux</span>
                   <div class="social-links">
-                    <a href="https://github.com/oiie25" target="_blank" rel="noopener noreferrer"
+                    <a href="https://github.com/ollo25" target="_blank" rel="noopener noreferrer"
                       >GitHub</a
                     >
                   </div>
@@ -340,8 +360,8 @@
               <p data-field="contact.availability">
                 En alternance active — réponse assurée sous 48h ouvrées.
               </p>
-              <a class="btn btn-primary" data-link="contact.cv" href="mailto:leoomnes25@gmail.com?subject=Demande%20de%20CV"
-                >Demander mon CV</a
+              <a class="btn btn-primary" data-link="contact.cv" href="cv/index.html"
+                >Consulter mon CV</a
               >
             </div>
           </div>

--- a/js/profile.js
+++ b/js/profile.js
@@ -2,43 +2,45 @@ const profile = {
   meta: {
     title: 'Portfolio - Léo OMNES | Développeur BTS SIO SLAM',
     description:
-      "Portfolio de Léo OMNES, étudiant en BTS SIO SLAM et assistant de suivi projets informatiques : compétences, réalisations et parcours.",
+      "Portfolio de Léo OMNES, étudiant en BTS SIO SLAM en alternance dans son lycée Robert Schuman, stage de plus d'un mois au même service et baccalauréat général (Maths, Physique-Chimie, option SVT abandonnée) au lycée Sainte Louise.",
     keywords: [
       'Léo Omnes',
       'BTS SIO',
       'SLAM',
       'développeur',
-      'alternance',
-      'SFR Business',
-      'portfolio développeur'
+      'alternance lycée',
+      'lycée Robert Schuman',
+      'stage développement',
+      'lycée Sainte Louise'
     ]
   },
   shortName: 'Léo Omnes',
   fullName: 'Léo OMNES',
-  tagline: 'Étudiant BTS SIO SLAM & assistant projets informatiques',
+  tagline:
+    'Étudiant BTS SIO SLAM & développeur en alternance dans mon lycée Robert Schuman',
   heroDescription:
-    "Étudiant en alternance chez SFR Business, je développe des solutions fiables en mettant l'accent sur l'automatisation, le suivi d'indicateurs et l'expérience utilisateur.",
+    "Étudiant en alternance et ancien stagiaire au lycée Robert Schuman, je conçois des outils numériques pour les équipes pédagogiques, j'automatise les reportings et j'accompagne les utilisateurs de l'établissement.",
   primaryCta: {
     label: 'Voir mes projets',
     url: '#projets'
   },
   secondaryCta: {
     label: 'Me contacter',
-    url: 'mailto:leoomnes25@gmail.com'
+    url: '#contact'
   },
   about: {
     title: 'À propos',
     paragraphs: [
-      "Actuellement en deuxième année de BTS Services Informatiques aux Organisations option SLAM au lycée Robert Schuman, j'alterne au sein de SFR Business sur des missions de suivi et d'optimisation des projets informatiques.",
-      "Je conçois des tableaux de bord, j'automatise l'envoi de rapports et j'assure un support opérationnel en adoptant des pratiques de développement rigoureuses et documentées.",
-      "Passionné par la programmation, l'escalade et les jeux vidéo, je reste en veille sur les nouvelles technologies pour proposer des expériences numériques utiles et engageantes."
+      "Alternant en BTS SIO option SLAM directement au lycée Robert Schuman, j'appuie le service numérique dans la modernisation des outils utilisés par les équipes pédagogiques.",
+      "Je développe et maintiens des applications internes, mets en place des automatisations pour fiabiliser les reportings et documente chaque procédure pour assurer la continuité des projets.",
+      "Après un stage de plus d'un mois au sein du même service, j'ai poursuivi l'aventure en alternance afin de faire évoluer les solutions internes tout en renforçant mes compétences techniques."
     ],
     highlights: [
       { label: 'Localisation', value: 'Paris 20e, France' },
       {
         label: 'Email',
-        value: 'leoomnes25@gmail.com',
-        link: 'mailto:leoomnes25@gmail.com'
+        value: 'leomnes25@gmail.com',
+        link: 'mailto:leomnes25@gmail.com'
       },
       { label: 'Anglais', value: 'Niveau courant' },
       {
@@ -47,8 +49,8 @@ const profile = {
       },
       {
         label: 'GitHub',
-        value: 'github.com/oiie25',
-        link: 'https://github.com/oiie25'
+        value: 'github.com/ollo25',
+        link: 'https://github.com/ollo25'
       }
     ]
   },
@@ -89,17 +91,17 @@ const profile = {
     items: [
       {
         period: '2024 — Aujourd’hui',
-        title: 'Assistant de suivi projets informatiques (alternance)',
-        organization: 'SFR Business',
+        title: 'Développeur en alternance (BTS SIO)',
+        organization: 'Lycée Robert Schuman — Services numériques',
         description:
-          "Supervision quotidienne des indicateurs de production, automatisation de l'envoi des rapports, administration de supports et coordination avec l'équipe data pour les tableaux de bord."
+          "Développement et maintenance d'outils internes pour le suivi pédagogique, automatisation des indicateurs et accompagnement des utilisateurs."
       },
       {
-        period: '2023',
-        title: 'Développeur web (stage)',
-        organization: 'GIC Informatique',
+        period: "2023 (stage de plus d'un mois)",
+        title: 'Stagiaire développeur applicatif',
+        organization: 'Lycée Robert Schuman — Services numériques',
         description:
-          "Maintenance d'applications métier, correction de bugs, conception d'interfaces de navigation, déploiement d'une solution d'accès à distance et support technique de niveau 1."
+          "Stage prolongé au sein du service numérique du lycée avec maintenance du portail interne, automatisation des reportings et formation des équipes administratives."
       },
       {
         period: '2024 — 2026',
@@ -109,59 +111,60 @@ const profile = {
           "Conception d'applications, gestion de bases de données, cybersécurité et gestion de projet en alternance."
       },
       {
-        period: '2022 — 2024',
-        title: 'Baccalauréat STI2D',
-        organization: 'Lycée Montaleau',
+        period: '2021 — 2024',
+        title: 'Baccalauréat général',
+        organization: 'Lycée Sainte Louise — Paris 20e',
         description:
-          'Spécialités Mathématiques, Numérique et Sciences de l’Ingénieur — mention bien.'
+          "Spécialités Mathématiques et Physique-Chimie ; option SVT suivie puis abandonnée en terminale au lycée Sainte Louise (Paris 20e)."
       }
     ]
   },
   projects: {
     title: 'Projets',
-    intro: 'Sélection de projets académiques et personnels illustrant mon approche terrain.',
+    intro:
+      'Projets menés au lycée Robert Schuman et durant mon BTS SIO SLAM.',
     filters: [
-      { label: 'Alternance' },
+      { label: 'Projets lycée' },
       { label: 'Développement web' },
-      { label: 'Data & reporting' }
+      { label: 'Automatisation & data' }
     ],
     items: [
       {
-        name: 'Application de concours national',
+        name: 'Portail de suivi pédagogique',
         description:
-          "Plateforme responsive pour gérer les inscriptions et votes d'un concours national avec synchronisation temps réel et tableaux de bord dédiés au comité d'organisation.",
-        technologies: ['Symfony', 'Bootstrap', 'JavaScript'],
-        links: [{ label: 'Aperçu GitHub', url: 'https://github.com/oiie25' }]
+          "Application interne du lycée pour centraliser les indicateurs, suivre les ateliers et partager les actions des équipes pédagogiques.",
+        technologies: ['Symfony', 'MySQL', 'Bootstrap'],
+        links: [{ label: 'Structure du dépôt', url: 'https://github.com/ollo25' }]
       },
       {
-        name: 'Gestion de base de données MySQL',
+        name: 'Automatisation des reportings',
         description:
-          "Modélisation, création de scripts SQL (requêtes, triggers) et génération de rapports analytiques pour piloter une base de données métier.",
-        technologies: ['MySQL', 'SQL', 'Talend'],
-        links: [{ label: 'Documentation', url: 'https://github.com/oiie25' }]
+          "Scripts Python et flux Talend pour générer les bilans mensuels et diffuser automatiquement les reportings aux équipes du lycée.",
+        technologies: ['Python', 'Talend Data Integration', 'SQL'],
+        links: [{ label: 'Exemples de scripts', url: 'https://github.com/ollo25' }]
       },
       {
         name: 'Portfolio personnel',
         description:
-          "Site vitrine développé en HTML, CSS et JavaScript avec animations légères et formulaire de contact pour valoriser mon parcours.",
+          "Site vitrine responsive présentant mon parcours BTS SIO, mes expériences au lycée et mes compétences techniques.",
         technologies: ['HTML', 'CSS', 'JavaScript'],
-        links: [{ label: 'Code source', url: 'https://github.com/oiie25/portfolio' }]
+        links: [{ label: 'Code source', url: 'https://github.com/ollo25/portfolio' }]
       }
     ]
   },
   contact: {
     title: 'Contact',
     subtitle:
-      "En alternance chez SFR Business, je reste disponible pour échanger sur vos projets et opportunités de collaboration.",
-    email: 'leoomnes25@gmail.com',
+      "En alternance et après mon stage au lycée Robert Schuman, je suis disponible pour échanger sur vos projets numériques, vos besoins en reporting ou une collaboration.",
+    email: 'leomnes25@gmail.com',
     phone: null,
     phoneNote: 'Disponible sur demande',
-    socials: [{ label: 'GitHub', url: 'https://github.com/oiie25' }],
+    socials: [{ label: 'GitHub', url: 'https://github.com/ollo25' }],
     availability:
       "En alternance active — réponse assurée sous 48h ouvrées.",
     cv: {
-      label: 'Demander mon CV',
-      url: 'mailto:leoomnes25@gmail.com?subject=Demande%20de%20CV'
+      label: 'Consulter mon CV',
+      url: 'cv/index.html'
     }
   },
   footer: {


### PR DESCRIPTION
## Summary
- ajouter un lien CV dans la navigation et une note de hero tout en conservant le style d’origine du portfolio
- actualiser le parcours, les projets et la section contact avec l’alternance dans le propre lycée, le stage prolongé et le bac général Maths/Physique (option SVT abandonnée)
- harmoniser la page CV autonome et les métadonnées avec ces informations mises à jour

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68ece5f7f99c832a9c50f00d80b616e9